### PR TITLE
Create exceptions

### DIFF
--- a/contrib/gravity_density/gravity_density.py
+++ b/contrib/gravity_density/gravity_density.py
@@ -10,7 +10,7 @@ import numpy as np
 from scipy.constants import G
 import matplotlib.pyplot as plt
 
-from cofi_espresso import EspressoProblem
+from cofi_espresso import EspressoProblem, InvalidExampleError
 from cofi_espresso.utils import loadtxt
 
 
@@ -54,7 +54,7 @@ class GravityDensity(EspressoProblem):
             for idx, name in enumerate(_to_expand):
                 self.params[name] = setup_params[idx]
         else:
-            raise ValueError(
+            raise InvalidExampleError(
                 "The example number supplied is not supported, please consult "
                 "Espresso documentation at "
                 "https://cofi-espresso.readthedocs.io/en/latest/contrib/index.html "

--- a/contrib/gravity_density/gravity_density.py
+++ b/contrib/gravity_density/gravity_density.py
@@ -54,12 +54,7 @@ class GravityDensity(EspressoProblem):
             for idx, name in enumerate(_to_expand):
                 self.params[name] = setup_params[idx]
         else:
-            raise InvalidExampleError(
-                "The example number supplied is not supported, please consult "
-                "Espresso documentation at "
-                "https://cofi-espresso.readthedocs.io/en/latest/contrib/index.html "
-                "for problem-specific metadata, e.g. number of examples provided"
-            )
+            raise InvalidExampleError
 
     @property
     def model_size(self):

--- a/contrib/simple_regression/simple_regression.py
+++ b/contrib/simple_regression/simple_regression.py
@@ -57,12 +57,7 @@ class SimpleRegression(EspressoProblem):
             self._desc = "Fitting a polynomial to a dataset with a gap"
             self._sigma = 0.1
         else:
-            raise InvalidExampleError(
-                "The example number supplied is not supported, please consult "
-                "Espresso documentation at "
-                "https://cofi-espresso.readthedocs.io/en/latest/contrib/index.html "
-                "for problem-specific metadata, e.g. number of examples provided"
-            )
+            raise InvalidExampleError
 
     @property
     def description(self):

--- a/contrib/simple_regression/simple_regression.py
+++ b/contrib/simple_regression/simple_regression.py
@@ -1,5 +1,5 @@
 import numpy as np
-from cofi_espresso import EspressoProblem
+from cofi_espresso import EspressoProblem, InvalidExampleError
 
 
 class SimpleRegression(EspressoProblem):
@@ -57,7 +57,7 @@ class SimpleRegression(EspressoProblem):
             self._desc = "Fitting a polynomial to a dataset with a gap"
             self._sigma = 0.1
         else:
-            raise ValueError(
+            raise InvalidExampleError(
                 "The example number supplied is not supported, please consult "
                 "Espresso documentation at "
                 "https://cofi-espresso.readthedocs.io/en/latest/contrib/index.html "

--- a/contrib/xray_tomography/xray_tomography.py
+++ b/contrib/xray_tomography/xray_tomography.py
@@ -37,12 +37,7 @@ class XrayTomography(EspressoProblem):
             self._start = np.ones((self._ngrid,self._ngrid))
             self._true = pngToModel('data/csiro_logo.png',self._ngrid,self._ngrid)
         else:
-            raise InvalidExampleError(
-                 "The example number supplied is not supported, please consult "
-                 "Espresso documentation at "
-                 "https://cofi-espresso.readthedocs.io/en/latest/contrib/index.html "
-                 "for problem-specific metadata, e.g. number of examples provided"
-            )
+            raise InvalidExampleError
 
     @property
     def description(self):

--- a/contrib/xray_tomography/xray_tomography.py
+++ b/contrib/xray_tomography/xray_tomography.py
@@ -1,5 +1,5 @@
 import numpy as np
-from cofi_espresso import EspressoProblem
+from cofi_espresso import EspressoProblem, InvalidExampleError
 from cofi_espresso.utils import loadtxt, absolute_path
 from PIL import Image
 import matplotlib.pyplot as plt
@@ -37,7 +37,7 @@ class XrayTomography(EspressoProblem):
             self._start = np.ones((self._ngrid,self._ngrid))
             self._true = pngToModel('data/csiro_logo.png',self._ngrid,self._ngrid)
         else:
-            raise ValueError(
+            raise InvalidExampleError(
                  "The example number supplied is not supported, please consult "
                  "Espresso documentation at "
                  "https://cofi-espresso.readthedocs.io/en/latest/contrib/index.html "

--- a/src/cofi_espresso/__init__.py
+++ b/src/cofi_espresso/__init__.py
@@ -1,4 +1,5 @@
 from .espresso_problem import EspressoProblem
+from .exceptions import EspressoError, InvalidExampleError
 
 
 try:
@@ -11,6 +12,8 @@ except ImportError:
 
 __all__ = [
     "EspressoProblem",
+    "EspressoError",
+    "InvalidExampleError",
 ]
 
 # from .example_name import ExampleName

--- a/src/cofi_espresso/exceptions.py
+++ b/src/cofi_espresso/exceptions.py
@@ -1,0 +1,11 @@
+class EspressoError(Exception):
+    """ Base class for all Espresso errors """
+    pass
+
+# Multiple inheritance means this can be caught by all of the following:
+# ... except InvalidExampleError
+# ... except EspressoError
+# ... except ValueError
+class InvalidExampleError(EspressoError, ValueError):
+    """ Raised if user attempts to instantiate an example number that does not exist """
+    pass

--- a/src/cofi_espresso/exceptions.py
+++ b/src/cofi_espresso/exceptions.py
@@ -8,4 +8,16 @@ class EspressoError(Exception):
 # ... except ValueError
 class InvalidExampleError(EspressoError, ValueError):
     """ Raised if user attempts to instantiate an example number that does not exist """
-    pass
+    def __init__(self, *args):
+        super().__init__(*args)
+    def __str__(self):
+        super_msg = super().__str__()
+        msg = "Unrecognised example number.\n\nPlease refer to the Espresso documentation " \
+              "(https://cofi-espresso.readthedocs.io/)\nfor full details of the examples " \
+              "provided within this test problem."
+        if len(super_msg)>0:
+            return msg+"\n\n"+super_msg
+        else:
+            return msg
+
+

--- a/utils/build_package/validate.py
+++ b/utils/build_package/validate.py
@@ -115,6 +115,7 @@ def test_contrib(contrib, pre_build):
         parent_mod = importlib.import_module(PKG_NAME)
     assert contrib_name_class in parent_mod.__all__
     contrib_class = getattr(parent_mod, contrib_name_class)
+    exception_class = getattr(parent_mod, "InvalidExampleError")
     
     # 4 - Check metadata is present within class
     assert type(contrib_class.problem_title) is str and len(contrib_class.problem_title)>0
@@ -142,7 +143,7 @@ def test_contrib(contrib, pre_build):
         #    model_size, data_size, good_model, starting_model, data, forward
         try:
             contrib_instance = contrib_class(i)
-        except ValueError:
+        except exception_class:
             # Assume that we've found all the examples
             n_examples = i-1
             assert n_examples > 0

--- a/utils/new_contribution/_template/example_name.py
+++ b/utils/new_contribution/_template/example_name.py
@@ -1,4 +1,4 @@
-from cofi_espresso import EspressoProblem
+from cofi_espresso import EspressoProblem, InvalidExampleError
 
 
 class ExampleName(EspressoProblem):
@@ -39,7 +39,7 @@ class ExampleName(EspressoProblem):
         #     self.some_attribute = some_value_1
         #     self.another_attribute = another_value_1
         # else:
-        #     raise ValueError(
+        #     raise InvalidExampleError(
         #         "The example number supplied is not supported, please consult "
         #         "Espresso documentation at "
         #         "https://cofi-espresso.readthedocs.io/en/latest/contrib/index.html "

--- a/utils/new_contribution/_template/example_name.py
+++ b/utils/new_contribution/_template/example_name.py
@@ -39,12 +39,7 @@ class ExampleName(EspressoProblem):
         #     self.some_attribute = some_value_1
         #     self.another_attribute = another_value_1
         # else:
-        #     raise InvalidExampleError(
-        #         "The example number supplied is not supported, please consult "
-        #         "Espresso documentation at "
-        #         "https://cofi-espresso.readthedocs.io/en/latest/contrib/index.html "
-        #         "for problem-specific metadata, e.g. number of examples provided"
-        #     )
+        #     raise InvalidExampleError
 
     @property
     def description(self):


### PR DESCRIPTION
First stab at a solution to #54. 

- Created `src/cofi_espresso/exceptions.py` to contain code; imported by `__init__.py`.
- Created `cofi_espresso.EspressoError` to use as base for all Espresso exceptions
- Created `cofi_espresso.InvalidExampleError` to be raised for invalid `example_number` values
- Modified existing examples and new-contribution template accordingly.

I was going to modify `/utils/build_package/validate.py` L145 to catch `InvalidExampleError` rather than `ValueError`. However this would require us to import it from `cofi_espresso` and I'm not sure whether/how it is best to do this in the context of this particular script. Since `InvalidExampleError` is subclassed from `ValueError`, the current version works OK - but it could be misled if a contribution raises a `ValueError` in other circumstances.