### PR TITLE
List problem and problem names from `cofi_espresso`

### DIFF
--- a/src/cofi_espresso/__init__.py
+++ b/src/cofi_espresso/__init__.py
@@ -17,4 +17,10 @@ __all__ = [
 ]
 
 # from .example_name import ExampleName
-# __all__.append("ExampleName")
+
+# __all_problem_names__ = [ "ExampleName", ]
+# __all__ += __all_problem_names__
+# list_problem_names = lambda: __all_problem_names__
+
+# __all_problems__ = [ ExampleName, ]
+# list_problems = lambda: __all_problems__

--- a/tools/build_package/build.py
+++ b/tools/build_package/build.py
@@ -76,6 +76,7 @@ def move_contrib_source():
     init_file_rtn_all_nms = "\nlist_problem_names = lambda: __all_problem_names__\n"
     init_file_all_cls += "]"
     init_file_rtn_all_cls = "\nlist_problems = lambda: __all_problems__\n"
+    init_file_add_funcs = "\n__all__ += ['list_problem_names', 'list_problems']\n"
     with open(f"{BUILD_DIR}/src/{PKG_NAME}/CMakeLists.txt", "a") as f:
         for contrib in contribs:
             f.write(f"install(DIRECTORY {contrib} DESTINATION .)\n")
@@ -86,6 +87,7 @@ def move_contrib_source():
         f.write(init_file_rtn_all_nms)
         f.write(init_file_all_cls)
         f.write(init_file_rtn_all_cls)
+        f.write(init_file_add_funcs)
 
 def install_pkg():
     subprocess.call([sys.executable, "-m", "pip", "uninstall", "-y", PKG_NAME])

--- a/tools/build_package/build.py
+++ b/tools/build_package/build.py
@@ -61,21 +61,31 @@ def move_contrib_source():
     move_folder_content(CONTRIB_SRC, f"{BUILD_DIR}/src/{PKG_NAME}")
     contribs = []
     init_file_imports = "\n"
-    init_file_all_var = "\n__additional_all__ = [\n"
+    init_file_all_nms = "\n__all_problem_names__ = [\n"
+    init_file_all_cls = "\n__all_problems__ = [\n"
     for path in Path(CONTRIB_SRC).iterdir():
         if path.is_dir():
             contrib = os.path.basename(path)
             contrib_class = contrib.title().replace("_", "")
             contribs.append(contrib)
             init_file_imports += f"from .{contrib} import {contrib_class}\n"
-            init_file_all_var += f"\t'{contrib_class}',\n"
-    init_file_all_var += "]\n__all__ += __additional_all__"
+            init_file_all_nms += f"\t'{contrib_class}',\n"
+            init_file_all_cls += f"\t{contrib_class},\n"
+    init_file_all_nms += "]"
+    init_file_add_all_nms = "\n__all__ += __all_problem_names__"
+    init_file_rtn_all_nms = "\nlist_problem_names = lambda: __all_problem_names__\n"
+    init_file_all_cls += "]"
+    init_file_rtn_all_cls = "\nlist_problems = lambda: __all_problems__\n"
     with open(f"{BUILD_DIR}/src/{PKG_NAME}/CMakeLists.txt", "a") as f:
         for contrib in contribs:
             f.write(f"install(DIRECTORY {contrib} DESTINATION .)\n")
     with open(f"{BUILD_DIR}/src/{PKG_NAME}/__init__.py", "a") as f:
         f.write(init_file_imports)
-        f.write(init_file_all_var)
+        f.write(init_file_all_nms)
+        f.write(init_file_add_all_nms)
+        f.write(init_file_rtn_all_nms)
+        f.write(init_file_all_cls)
+        f.write(init_file_rtn_all_cls)
 
 def install_pkg():
     subprocess.call([sys.executable, "-m", "pip", "uninstall", "-y", PKG_NAME])


### PR DESCRIPTION
Two functions are implemented: 

- `cofi_espresso.list_problems()`, returns a list of classes (suitable for automatic checking stuff)
- `cofi_espresso.list_problem_names()`, returns a list of class names

Here are sample outputs:

```
>>> import cofi_espresso
>>> cofi_espresso.list_problems()
[<class 'cofi_espresso.simple_regression.simple_regression.SimpleRegression'>, <class 'cofi_espresso.xray_tomography.xray_tomography.XrayTomography'>, <class 'cofi_espresso.gravity_density.gravity_density.GravityDensity'>]
>>> cofi_espresso.list_problem_names()
['SimpleRegression', 'XrayTomography', 'GravityDensity']
```

Function `move_contrib_source()` in file `tools/build_package/build.py` was modified to implement this.

Some reviews and feedback from @valentineap would be great - is there a better naming? Are there other similar requirements worth implementing along with this PR?

(To close #52)