### PR TITLE
chore: relax scipy version restriction

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,7 +2,7 @@ name: readthedocs
 dependencies:
   - python=3.10
   - matplotlib>=3.5.0
-  - scipy<1.13.0    # TODO remove this after seislib releases new version
+  - scipy
   - cython
   - obspy
   - cartopy

--- a/envs/requirements_test.txt
+++ b/envs/requirements_test.txt
@@ -2,8 +2,7 @@ pytest
 pyyaml
 numpy
 matplotlib
-# scipy<1.13.0; python_version<"3.10"
-scipy<1.13.0    # TODO remove this after seislib releases new version
+scipy
 tqdm
 cython
 scikit-build-core


### PR DESCRIPTION
## Description

Relax the SciPy version restriction put on earlier, now that seislib has released a new version and it shouldn't break from SciPy's change after 1.13.

## Type of Change

Please indicate the type of change this pull request represents:

- [ ] New Espresso problem or example
- [ ] Espresso core
- [ ] Espresso machine
- [ ] Documentation
- [x] Others (change in testing and documentation environment)
