### PR TITLE
Ci/buildwheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -12,15 +12,21 @@ on:
 jobs:
   build_wheels_non_windows:
     if: github.repository_owner == 'inlab-geo'
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }} for ${{ matrix.cibw_python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         # Giving up windows, see the following two links:
         # https://groups.google.com/g/comp.lang.fortran/c/Jna-QAHCOpk/m/VZq7gVq3AgAJ
         # https://github.com/awvwgk/setup-fortran/issues/6
         # os: [ubuntu-latest, macos-latest]
         os: [ubuntu-latest, macos-latest]
+        # cibuildwheel can change python versions (that's part of the point)
+        # but with the complicated build system I've found it easier to divide
+        # up the python versions into their own GHActions jobs
+        # Plus then they run in parallel
+        cibw_python-version: [cp39, cp310, cp311, cp312, cp313]
 
     steps:
       - name: Checkout
@@ -40,40 +46,41 @@ jobs:
       - name: Setup GNU Fortran
         uses: fortran-lang/setup-fortran@v1
         id: setup-fortran
-      
-      - name: Prepare extra dependencies for Cartopy (MacOS)
-        if: matrix.os == 'macOS-latest'
-        run: |
-          brew install geos
 
-      - name: Prepare extra dependencies for Cartopy (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
+      - name: Trick cibuildwheel
+        # cibuild wheel requires e.g. a pyproject.toml file in the package dir
+        # which in our case is _esp_build but this doesn't get created until
+        # the CIBW_BEFORE_BUILD step, which happens after option validation.
+        # So here I just copy our pyproject.toml into a fresh _esp_build dir,
+        # which will get overwritten later
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libgeos++-dev
-
-      - name: Prepare Python environment
-        run: |
-          python -m pip install -r envs/requirements_test.txt
-          python -m pip install scikit-build versioningit build
-          python -m pip install .
-
-      - name: Generate package source with contributions
-        run: |
-          python espresso_machine/build_package/build.py -f contrib/active_problems.txt
+          mkdir -p _esp_build
+          cp pyproject.toml _esp_build
 
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
-        working-directory: _esp_build
+        uses: pypa/cibuildwheel@v2.22
+        with:
+          package-dir: _esp_build
+          output-dir: wheelhouse
         env:
-          CIBW_SKIP: pp* cp36* cp37* cp312* *-win32 *-manylinux_i686 *-musllinux_*
+          CIBW_BUILD: '${{ matrix.cibw_python-version }}*'
+          CIBW_SKIP: '*-manylinux_i686 *-musllinux_*'
+          CIBW_BEFORE_BUILD: >
+            pip install -r envs/requirements_test.txt &&
+            pip install . &&
+            python espresso_machine/build_package/build.py -f contrib/active_problems.txt
+
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_BEFORE_ALL_LINUX: > 
+            yum install -y epel-release &&
+            yum install -y geos geos-devel
+
+          CIBW_BEFORE_ALL_MACOS: brew install geos
           CIBW_ARCHS_MACOS: arm64
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
-          CIBW_TEST_COMMAND_MACOS: "python -c 'from espresso import *'"
-          # couldn't get cartopy to install in the testing virtual environment on linux
+          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=14.0
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{matrix.os}}-wheels
-          path: _esp_build/wheelhouse/
+          name: ${{matrix.os}}-${{ matrix.cibw_python-version }}-wheels
+          path: wheelhouse/geo_espresso*.whl

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -121,63 +121,78 @@ jobs:
 
   ######################## WHEELS DISTRIBUTION #########################
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    needs: tag_pkg_source
+    name: Build wheels on ${{ matrix.os }} for ${{ matrix.cibw_python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         # Giving up windows, see the following two links:
         # https://groups.google.com/g/comp.lang.fortran/c/Jna-QAHCOpk/m/VZq7gVq3AgAJ
         # https://github.com/awvwgk/setup-fortran/issues/6
+        # os: [ubuntu-latest, macos-latest]
         os: [ubuntu-latest, macos-latest]
+        # cibuildwheel can change python versions (that's part of the point)
+        # but with the complicated build system I've found it easier to divide
+        # up the python versions into their own GHActions jobs
+        # Plus then they run in parallel
+        cibw_python-version: [cp39, cp310, cp311, cp312, cp313]
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v2
         with:
-          ref: esp_build
           fetch-depth: 0
 
       - name: Get tags
         run: |
           git fetch --tags origin
-          git describe --tags
+          git describe
 
-      - name: Install Python 3.10
-        uses: actions/setup-python@v4
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-  
+      
       - name: Setup GNU Fortran
         uses: fortran-lang/setup-fortran@v1
         id: setup-fortran
-  
-      - name: Install dependencies (MacOS)
-        if: matrix.os == 'macOS-latest'
+
+      - name: Trick cibuildwheel
+        # cibuild wheel requires e.g. a pyproject.toml file in the package dir
+        # which in our case is _esp_build but this doesn't get created until
+        # the CIBW_BEFORE_BUILD step, which happens after option validation.
+        # So here I just copy our pyproject.toml into a fresh _esp_build dir,
+        # which will get overwritten later
         run: |
-          brew install geos
-  
-      - name: Install dependencies (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgeos++-dev
-      
-      - name: Set up environment
-        run: |
-          python -m pip install scikit-build-core versioningit cibuildwheel
+          mkdir -p _esp_build
+          cp pyproject.toml _esp_build
 
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
+        uses: pypa/cibuildwheel@v2.22
+        with:
+          package-dir: _esp_build
+          output-dir: wheelhouse
         env:
-          CIBW_SKIP: pp* cp36* cp37* cp312* *-win32 *-manylinux_i686 *-musllinux_*
+          CIBW_BUILD: '${{ matrix.cibw_python-version }}*'
+          CIBW_SKIP: '*-manylinux_i686 *-musllinux_*'
+          CIBW_BEFORE_BUILD: >
+            pip install -r envs/requirements_test.txt &&
+            pip install . &&
+            python espresso_machine/build_package/build.py -f contrib/active_problems.txt
+
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_BEFORE_ALL_LINUX: > 
+            yum install -y epel-release &&
+            yum install -y geos geos-devel
+
+          CIBW_BEFORE_ALL_MACOS: brew install geos
           CIBW_ARCHS_MACOS: arm64
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
+          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=14.0
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          path: ./wheelhouse/
-          name: ${{matrix.os}}-wheels
-          if-no-files-found: error
+          name: ${{matrix.os}}-${{ matrix.cibw_python-version }}-wheels
+          path: wheelhouse/geo_espresso*.whl
 
 
   ######################## UPLOAD TO PYPI #########################

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -207,17 +207,17 @@ jobs:
           merge-multiple: true
           path: dist
 
-      # - name: Publish package to TestPyPI
-      #   uses: pypa/gh-action-pypi-publish@v1.4.1
-      #   with:
-      #     user: __token__
-      #     password: ${{ secrets.TEST_PYPI_TOKEN }}
-      #     repository_url: https://test.pypi.org/legacy/
-      #     verbose: true
+      - name: Publish package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@v1.4.1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          verbose: true
 
-      # - name: Publish package to PyPI
-      #   uses: pypa/gh-action-pypi-publish@v1.4.1
-      #   with:
-      #     user: __token__
-      #     password: ${{ secrets.PYPI_TOKEN }}
-      #     verbose: true
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.4.1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}
+          verbose: true

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -207,17 +207,17 @@ jobs:
           merge-multiple: true
           path: dist
 
-      - name: Publish package to TestPyPI
-        uses: pypa/gh-action-pypi-publish@v1.4.1
-        with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-          verbose: true
+      # - name: Publish package to TestPyPI
+      #   uses: pypa/gh-action-pypi-publish@v1.4.1
+      #   with:
+      #     user: __token__
+      #     password: ${{ secrets.TEST_PYPI_TOKEN }}
+      #     repository_url: https://test.pypi.org/legacy/
+      #     verbose: true
 
-      - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.4.1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
-          verbose: true
+      # - name: Publish package to PyPI
+      #   uses: pypa/gh-action-pypi-publish@v1.4.1
+      #   with:
+      #     user: __token__
+      #     password: ${{ secrets.PYPI_TOKEN }}
+      #     verbose: true


### PR DESCRIPTION
# Espresso Pull Request Template

## Description

Prompted by #192, this builds the wheels for linux and macos including the repair wheels step.  Wheels are only available for macos>=14 Sonoma.  This should mean that binaries for `FmmTomography` and `ReceiverFunctionKnt` are in the right place and can be accessed when initialised or called from the classes.


