### PR TITLE
ci: fix job order

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -122,6 +122,7 @@ jobs:
   ######################## WHEELS DISTRIBUTION #########################
   build_wheels:
     name: Build wheels on ${{ matrix.os }} for ${{ matrix.cibw_python-version }}
+    needs: tag_pkg_source
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
When updating the ci (#197) to build the wheels I missed ensuring that the wheels only get built after the package tagging